### PR TITLE
Deserialise bounding box

### DIFF
--- a/compute_rhino3d/GeometryBase.py
+++ b/compute_rhino3d/GeometryBase.py
@@ -21,6 +21,7 @@ def GetBoundingBox(thisGeometryBase, accurate, multiple=False):
     args = [thisGeometryBase, accurate]
     if multiple: args = zip(thisGeometryBase, accurate)
     response = Util.ComputeFetch(url, args)
+    response = Util.DecodeToBoundingBox(response)
     return response
 
 
@@ -41,6 +42,7 @@ def GetBoundingBox1(thisGeometryBase, xform, multiple=False):
     args = [thisGeometryBase, xform]
     if multiple: args = zip(thisGeometryBase, xform)
     response = Util.ComputeFetch(url, args)
+    response = Util.DecodeToBoundingBox(response)
     return response
 
 

--- a/compute_rhino3d/Util.py
+++ b/compute_rhino3d/Util.py
@@ -93,3 +93,10 @@ def DecodeToLine(item):
     end = DecodeToPoint3d(item['To'])
     return rhino3dm.Line(start,end)
 
+
+def DecodeToBoundingBox(item):
+    if item is None:
+        return None
+    if isinstance(item, list):
+        return [DecodeToBoundingBox(x) for x in item]
+    return rhino3dm.BoundingBox(item['Min']['X'], item['Min']['Y'], item['Min']['Z'], item['Max']['X'], item['Max']['Y'], item['Max']['Z'])


### PR DESCRIPTION
Deserialises bounding box dict to `rhino3dm.BoundingBox` when returned from Compute, e.g. `GeometryBase.GetBoundingBox()`.

See https://discourse.mcneel.com/t/bounding-boxes-for-trimmed-surfaces/108529