### PR TITLE
raise exception with raw response body from ComputeFetch if the response isn't json

### DIFF
--- a/compute_rhino3d/Util.py
+++ b/compute_rhino3d/Util.py
@@ -32,7 +32,9 @@ def ComputeFetch(endpoint, arglist):
     if apiKey:
         headers['RhinoComputeKey'] = apiKey
     r = requests.post(posturl, data=postdata, headers=headers)
-    return r.json()
+    if r.headers.get('content-type').lower() == 'application/json':
+        return r.json()
+    raise Exception("Error from compute endpoint\n{}".format(r.text))
 
 
 def PythonEvaluate(script, inputs, output_names):


### PR DESCRIPTION
**Problem**
Error thrown when ComputeFetch tries to decode a non JSON response as JSON. The error masks the underlying problem and makes it hard to debug. This happens during non 2xx http code responses. For example if you use a hostname other than the one your compute server is bound to, you'll get the following python error

```
Traceback (most recent call last):
  File "/Volumes/CSFS/workspaces/CPTInsole/src/CPTInsole/lambda/rhino/lib/python3.10/site-packages/requests/models.py", line 971, in json
    return complexjson.loads(self.text, **kwargs)
  File "/Users/jurobn/.pyenv/versions/3.10.3/lib/python3.10/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/Users/jurobn/.pyenv/versions/3.10.3/lib/python3.10/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/Users/jurobn/.pyenv/versions/3.10.3/lib/python3.10/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Volumes/CSFS/workspaces/CPTInsole/src/CPTInsole/lambda/app.py", line 123, in <module>
    handler(None, None)
  File "/Volumes/CSFS/workspaces/CPTInsole/src/CPTInsole/lambda/app.py", line 32, in handler
    output = gh.EvaluateDefinition('design_automation.working-base64-input.gh', trees)
  File "/Volumes/CSFS/workspaces/CPTInsole/src/CPTInsole/lambda/rhino/lib/python3.10/site-packages/compute_rhino3d/Grasshopper.py", line 57, in EvaluateDefinition
    response = Util.ComputeFetch(url, args)
  File "/Volumes/CSFS/workspaces/CPTInsole/src/CPTInsole/lambda/rhino/lib/python3.10/site-packages/compute_rhino3d/Util.py", line 36, in ComputeFetch
    return r.json()
  File "/Volumes/CSFS/workspaces/CPTInsole/src/CPTInsole/lambda/rhino/lib/python3.10/site-packages/requests/models.py", line 975, in json
    raise RequestsJSONDecodeError(e.msg, e.doc, e.pos)
requests.exceptions.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

**Solution**
throw an exception with the raw response if response isn't json

**Testing**
Locally I still get an error but one that gives me useful information.
```
Traceback (most recent call last):
  File "/Volumes/CSFS/workspaces/CPTInsole/src/CPTInsole/lambda/app.py", line 123, in <module>
    handler(None, None)
  File "/Volumes/CSFS/workspaces/CPTInsole/src/CPTInsole/lambda/app.py", line 32, in handler
    output = gh.EvaluateDefinition('design_automation.working-base64-input.gh', trees)
  File "/Volumes/CSFS/workspaces/CPTInsole/src/CPTInsole/lambda/rhino/lib/python3.10/site-packages/compute_rhino3d/Grasshopper.py", line 57, in EvaluateDefinition
    response = Util.ComputeFetch(url, args)
  File "/Volumes/CSFS/workspaces/CPTInsole/src/CPTInsole/lambda/rhino/lib/python3.10/site-packages/compute_rhino3d/Util.py", line 37, in ComputeFetch
    raise Exception("Error from compute endpoint\n{}".format(r.text))
Exception: Error from compute endpoint
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN""http://www.w3.org/TR/html4/strict.dtd">
<HTML><HEAD><TITLE>Bad Request</TITLE>
<META HTTP-EQUIV="Content-Type" Content="text/html; charset=us-ascii"></HEAD>
<BODY><h2>Bad Request - Invalid Hostname</h2>
<hr><p>HTTP Error 400. The request hostname is invalid.</p>
</BODY></HTML>
```